### PR TITLE
Remove the cats dependency

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,3 +1,5 @@
+version = 3.7.3
+
 style = defaultWithAlign
 maxColumn = 120
 lineEndings = unix

--- a/build.sbt
+++ b/build.sbt
@@ -13,8 +13,7 @@ lazy val releaseVersioning = Project("release-versioning", file("."))
   )
 
 val compileDependencies = Seq(
-  "com.github.scopt" %% "scopt"     % "3.7.1",
-  "org.typelevel"    %% "cats-core" % "1.2.0"
+  "com.github.scopt" %% "scopt"     % "3.7.1"
 )
 
 val testDependencies = Seq(

--- a/src/main/scala/uk/gov/hmrc/versioning/Main.scala
+++ b/src/main/scala/uk/gov/hmrc/versioning/Main.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,9 @@
 
 package uk.gov.hmrc.versioning
 
-import cats.implicits._
 import scopt.OptionParser
+
+import scala.util.Try
 
 object Main {
 
@@ -36,7 +37,7 @@ object Main {
     }
 
   private def toVersion(args: Args) =
-    Either.catchNonFatal {
+    Try {
       calculateNextVersion(
         args.release,
         args.hotfix,
@@ -44,7 +45,7 @@ object Main {
         args.maybeGitDescribe,
         majorVersion = args.maybeMajorVersion.getOrElse(0)
       )
-    }
+    }.toEither
 
   private case class Args(
     release: Boolean                 = false,

--- a/src/main/scala/uk/gov/hmrc/versioning/ReleaseVersioning.scala
+++ b/src/main/scala/uk/gov/hmrc/versioning/ReleaseVersioning.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/versioning/ReleaseVersioningSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/versioning/ReleaseVersioningSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Love cats, but this version is quite old, and this gets pulled into everything via sbt-auto-build->sbt-git-versioning->release-versioning 😁 

You're probably wondering why I am working on this - at Opencast we have some training repositories that make use of HMRC libraries in order to familiarise our consultants with HMRC's environment and development style.